### PR TITLE
Added Kafdrop link

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ Everything about Apache Kafka
 ### UI
 * [kafka-manager](https://github.com/yahoo/kafka-manager)
 * [Kafka HQ](https://github.com/tchiotludo/kafkahq)
-* [Kafdrop](https://github.com/HomeAdvisor/Kafdrop)
+* [Kafdrop 2.x](https://github.com/HomeAdvisor/Kafdrop) – web UI for legacy Kafka brokers (older than 0.10.0)
+* [Kafdrop 3.x](https://github.com/obsidiandynamics/kafdrop) – web UI Kafka 0.10.0 and newer
 * [Kafka Webview](https://github.com/SourceLabOrg/kafka-webview)
 * [Kafka Topics UI](https://github.com/Landoop/kafka-topics-ui)
 * [Kafka Connect UI](https://github.com/Landoop/kafka-connect-ui)

--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ Everything about Apache Kafka
 ### UI
 * [kafka-manager](https://github.com/yahoo/kafka-manager)
 * [Kafka HQ](https://github.com/tchiotludo/kafkahq)
-* [Kafdrop 2.x](https://github.com/HomeAdvisor/Kafdrop) – web UI for legacy Kafka brokers (older than 0.10.0)
-* [Kafdrop 3.x](https://github.com/obsidiandynamics/kafdrop) – web UI Kafka 0.10.0 and newer
+* [Kafdrop 3.x](https://github.com/obsidiandynamics/kafdrop) – web UI for Kafka. For versions older than 0.10.0 use [Kafdrop 2.x](https://github.com/HomeAdvisor/Kafdrop).
 * [Kafka Webview](https://github.com/SourceLabOrg/kafka-webview)
 * [Kafka Topics UI](https://github.com/Landoop/kafka-topics-ui)
 * [Kafka Connect UI](https://github.com/Landoop/kafka-connect-ui)


### PR DESCRIPTION
Refined the Kafdrop link to include the repository for legacy brokers as well as the 3.x repo for newer brokers